### PR TITLE
disallow reverse fish movement

### DIFF
--- a/Assets/Scripts/AI/Evolution/EvolutionManager.cs
+++ b/Assets/Scripts/AI/Evolution/EvolutionManager.cs
@@ -166,6 +166,7 @@ public class EvolutionManager : MonoBehaviour
         if (isMiniGame && saveParameters != "")
         {
             geneticAlgorithm = new GeneticAlgorithm((uint) nn.WeightCount, (uint) PopulationSize, saveParameters);
+            geneticAlgorithm.InitialisePopulation = GeneticAlgorithm.DoNotPopulationInitialisation; // should ignore the randomization portion of parameters
         }
 
         else

--- a/Assets/Scripts/AI/Evolution/GeneticAlgorithm.cs
+++ b/Assets/Scripts/AI/Evolution/GeneticAlgorithm.cs
@@ -310,6 +310,12 @@ public class GeneticAlgorithm
             genotype.SetRandomParameters(DefInitParamMin, DefInitParamMax);
     }
 
+    public static void DoNotPopulationInitialisation(IEnumerable<Genotype> population)
+    {
+        // do nothing here because we are copying fish parameters, no need to randomize
+        UnityEngine.Debug.Log("No need to do random init. of parameters");
+    }
+
     public static void AsyncEvaluation(IEnumerable<Genotype> currentPopulation)
     {
         //At this point the async evaluation should be started and after it is finished EvaluationFinished should be called

--- a/Assets/Scripts/Minigame Scripts/CatchFish.cs
+++ b/Assets/Scripts/Minigame Scripts/CatchFish.cs
@@ -11,7 +11,17 @@ public class CatchFish : MonoBehaviour
     void Start(){
         score = 0;
     }
+
+    // not really sure why the other method is incompatible with the smart salmon
+    void OnCollisionEnter2D(Collision2D collision) {
+
+        if (collision.collider.gameObject.tag == "AI Salmon") {
+            score++;
+            scoreText.text = score.ToString();
+        }
+    }
     private void OnTriggerEnter2D(Collider2D other) {
+
         if (other.gameObject.tag == "AI Salmon"){
             Destroy(other.gameObject);
             score++;

--- a/Assets/Scripts/Minigame Scripts/SpawnSalmon.cs
+++ b/Assets/Scripts/Minigame Scripts/SpawnSalmon.cs
@@ -42,7 +42,7 @@ public class SpawnSalmon : MonoBehaviour
             float x = Random.Range(xMin, xMax);
             float y = Random.Range(yMin, yMax);
 
-            Instantiate(salmonPrefab, new Vector3(x, y, 0), Quaternion.identity);
+           // Instantiate(salmonPrefab, new Vector3(x, y, 0), Quaternion.identity);
         }
 
         UpdateTimerText();

--- a/Assets/Scripts/Simulation/CarMovement.cs
+++ b/Assets/Scripts/Simulation/CarMovement.cs
@@ -92,16 +92,17 @@ public class CarMovement : MonoBehaviour
     private void ApplyInput()
     {
         //Cap input 
-        if (verticalInput > 1)
-            verticalInput = 1;
-        else if (verticalInput < -1)
-            verticalInput = -1;
+        if (verticalInput > 1.5)
+            verticalInput = 1.5;
 
+        else if (verticalInput < 0)
+            verticalInput = -verticalInput; // normalize to only positive y direction
+/*
         if (horizontalInput > 1)
             horizontalInput = 1;
         else if (horizontalInput < -1)
             horizontalInput = -1;
-
+*/
         //Car can only accelerate further if velocity is lower than engineForce * MAX_VEL
         bool canAccelerate = false;
         if (verticalInput < 0)


### PR DESCRIPTION
- salmon can no longer "reverse" (still multidirectional, but only positive velocity is applied)

- score in the minigame is now updated when the bear catches smart salmon
- "stupid" salmon no longer show up in the minigame
- additional initialization method that does "nothing" added so that parameters that are loaded into the minigame for the fish are not overwritten with random ones