### PR TITLE
Connergg testing

### DIFF
--- a/Assets/Scenes/TestBearMiniGame.unity
+++ b/Assets/Scenes/TestBearMiniGame.unity
@@ -2796,7 +2796,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   gameMenu: {fileID: 706657501}
-  scoreText: {fileID: 2090872729}
+  scoreText: {fileID: 1260221794}
   pauseMenu: {fileID: 404758255}
   tutorial: {fileID: 1597185068}
   timeAndScore: {fileID: 393977604}

--- a/Assets/Scenes/TestBearMiniGame.unity
+++ b/Assets/Scenes/TestBearMiniGame.unity
@@ -16859,7 +16859,7 @@ MonoBehaviour:
   SaveStatistics: 0
   isMiniGame: 1
   SaveFirstNGenotype: 0
-  totalGenerationCount: 10
+  totalGenerationCount: 0
   ElitistSelection: 1
   FNNTopology: 05000000040000000300000002000000
   endTrainingMenu: {fileID: 0}

--- a/Assets/Scripts/AI/Evolution/EvolutionManager.cs
+++ b/Assets/Scripts/AI/Evolution/EvolutionManager.cs
@@ -7,6 +7,7 @@ using UnityEngine;
 using System.Collections.Generic;
 using System;
 using System.IO;
+using TMPro;
 #endregion
 
 
@@ -279,6 +280,9 @@ public class EvolutionManager : MonoBehaviour
         if (endTrainingMenu != null)
         {
             endTrainingMenu.SetActive(true);
+            TextMeshProUGUI evalText = GameObject.Find("Evaluation").GetComponent<TextMeshProUGUI>();
+            TextMeshProUGUI endTrainingScoreText = GameObject.Find("EndGameScoreText").GetComponent<TextMeshProUGUI>();
+            endTrainingScoreText.text = "Score: " + evalText.text;
         }
     }
 

--- a/Assets/Scripts/Simulation/CarController.cs
+++ b/Assets/Scripts/Simulation/CarController.cs
@@ -25,7 +25,7 @@ public class CarController : MonoBehaviour
     #endregion
 
     // Maximum delay in seconds between the collection of two checkpoints until this car dies.
-    private const float MAX_CHECKPOINT_DELAY = 7;
+    private const float MAX_CHECKPOINT_DELAY = 3;
 
     /// <summary>
     /// The underlying AI agent of this car.

--- a/Assets/Scripts/Simulation/CarMovement.cs
+++ b/Assets/Scripts/Simulation/CarMovement.cs
@@ -21,7 +21,7 @@ public class CarMovement : MonoBehaviour
     private float MAX_VEL = 20f;
     private float ACCELERATION = 8f;
     private float VEL_FRICT = 2f;
-    private float TURN_SPEED = 100;
+    private float TURN_SPEED = 200;
 
     private CarController controller;
 

--- a/Assets/Scripts/Simulation/Checkpoint.cs
+++ b/Assets/Scripts/Simulation/Checkpoint.cs
@@ -17,6 +17,12 @@ public class Checkpoint : MonoBehaviour
     /// </summary>
     public float CaptureRadius = 5;
     private SpriteRenderer spriteRenderer;
+    
+    // bounds are pretty much the box that surrounds the transform vector
+    public Bounds bounds {
+        get;
+        set;
+    }
 
     /// <summary>
     /// The reward value earned by capturing this checkpoint.
@@ -68,6 +74,8 @@ public class Checkpoint : MonoBehaviour
     void Awake()
     {
         spriteRenderer = GetComponent<SpriteRenderer>();
+        Debug.Log(spriteRenderer.bounds);
+        bounds = spriteRenderer.bounds;
     }
     #endregion
 

--- a/Assets/Scripts/Simulation/TrackManager.cs
+++ b/Assets/Scripts/Simulation/TrackManager.cs
@@ -284,7 +284,11 @@ public class TrackManager : MonoBehaviour
             return 1;
 
         //Calculate distance to next checkpoint
-        float checkPointDistance = Vector2.Distance(car.transform.position, checkpoints[curCheckpointIndex].transform.position);
+
+        // compute the point on the checkpoint surface that is closest to the salmon's position
+        Vector3 closestPoint = checkpoints[curCheckpointIndex].bounds.ClosestPoint(car.transform.position);
+        float checkPointDistance = Vector2.Distance(car.transform.position, closestPoint);
+        // float checkPointDistance = Vector2.Distance(car.transform.position, checkpoints[curCheckpointIndex].transform.position);
        // Debug.Log("Distance to next checkpoint: " + checkPointDistance);
 
         //Check if checkpoint can be captured


### PR DESCRIPTION
- reward computation that involves determining distance from checkpoints has now been fixed. As a consequence the "best fish" camera also works as it used to (just following the best performing fish, even when it dies)

- end training popup now shows the same fitness score value as the ingame training
- minigame end score is also now assigned properly